### PR TITLE
Replace HTML5 deprecated tag <tt> with <code>

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # English
 
 Include the English library file in a Ruby script, and you can
-reference the global variables such as <tt>$_</tt> using less
+reference the global variables such as <code>$_</code> using less
 cryptic names, listed below.
 
 ## Installation

--- a/lib/English.rb
+++ b/lib/English.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 #  Include the English library file in a Ruby script, and you can
-#  reference the global variables such as <tt>$_</tt> using less
+#  reference the global variables such as <code>$_</code> using less
 #  cryptic names, listed below.
 #
 #  Without 'English':
@@ -56,11 +56,11 @@ alias $ERROR_INFO              $!
 alias $ERROR_POSITION          $@
 
 # The default separator pattern used by String#split.  May be set from
-# the command line using the <tt>-F</tt> flag.
+# the command line using the <code>-F</code> flag.
 alias $FS                      $;
 
 # The default separator pattern used by String#split.  May be set from
-# the command line using the <tt>-F</tt> flag.
+# the command line using the <code>-F</code> flag.
 alias $FIELD_SEPARATOR         $;
 
 # The separator string output between the parameters to methods such
@@ -99,37 +99,37 @@ alias $NR                      $.
 
 # The last line read by Kernel#gets or
 # Kernel#readline. Many string-related functions in the
-# Kernel module operate on <tt>$_</tt> by default. The variable is
+# Kernel module operate on <code>$_</code> by default. The variable is
 # local to the current scope. Thread local.
 alias $LAST_READ_LINE          $_
 
 # The destination of output for Kernel#print
 # and Kernel#printf. The default value is
-# <tt>$stdout</tt>.
+# <code>$stdout</code>.
 alias $DEFAULT_OUTPUT          $>
 
 # An object that provides access to the concatenation
 # of the contents of all the files
-# given as command-line arguments, or <tt>$stdin</tt>
+# given as command-line arguments, or <code>$stdin</code>
 # (in the case where there are no
-# arguments). <tt>$<</tt> supports methods similar to a
+# arguments). <code>$<</code> supports methods similar to a
 # File object:
 # +inmode+, +close+,
-# <tt>closed?</tt>, +each+,
-# <tt>each_byte</tt>, <tt>each_line</tt>,
-# +eof+, <tt>eof?</tt>, +file+,
+# <code>closed?</code>, +each+,
+# <code>each_byte</code>, <code>each_line</code>,
+# +eof+, <code>eof?</code>, +file+,
 # +filename+, +fileno+,
 # +getc+, +gets+, +lineno+,
-# <tt>lineno=</tt>, +path+,
-# +pos+, <tt>pos=</tt>,
+# <code>lineno=</code>, +path+,
+# +pos+, <code>pos=</code>,
 # +read+, +readchar+,
 # +readline+, +readlines+,
 # +rewind+, +seek+, +skip+,
-# +tell+, <tt>to_a</tt>, <tt>to_i</tt>,
-# <tt>to_io</tt>, <tt>to_s</tt>, along with the
+# +tell+, <code>to_a</code>, <code>to_i</code>,
+# <code>to_io</code>, <code>to_s</code>, along with the
 # methods in Enumerable. The method +file+
 # returns a File object for the file currently
-# being read. This may change as <tt>$<</tt> reads
+# being read. This may change as <code>$<</code> reads
 # through the files on the command line. Read only.
 alias $DEFAULT_INPUT           $<
 
@@ -144,9 +144,9 @@ alias $PROCESS_ID              $$
 alias $CHILD_STATUS            $?
 
 # A +MatchData+ object that encapsulates the results of a successful
-# pattern match. The variables <tt>$&</tt>, <tt>$`</tt>, <tt>$'</tt>,
-# and <tt>$1</tt> to <tt>$9</tt> are all derived from
-# <tt>$~</tt>. Assigning to <tt>$~</tt> changes the values of these
+# pattern match. The variables <code>$&</code>, <code>$`</code>, <code>$'</code>,
+# and <code>$1</code> to <code>$9</code> are all derived from
+# <code>$~</code>. Assigning to <code>$~</code> changes the values of these
 # derived variables.  This variable is local to the current
 # scope.
 alias $LAST_MATCH_INFO         $~
@@ -176,7 +176,7 @@ alias $PREMATCH                $`
 alias $POSTMATCH               $'
 
 # The contents of the highest-numbered group matched in the last
-# successful pattern match. Thus, in <tt>"cat" =~ /(c|a)(t|z)/</tt>,
-# <tt>$+</tt> will be set to "t".  This variable is local to the
+# successful pattern match. Thus, in <code>"cat" =~ /(c|a)(t|z)/</code>,
+# <code>$+</code> will be set to "t".  This variable is local to the
 # current scope. Read only.
 alias $LAST_PAREN_MATCH        $+


### PR DESCRIPTION
As the title describes, `<tt>` is not supported by HTML5. 

Although the generated `rdoc` documents transform `<tt>` to `<code>` behind the scene. I think it's still good to replace old styled tags.